### PR TITLE
Add LinearRegressionEager.fs, Ignore FunctionApproximation.fs for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,5 @@ ASALocalRun/
 .mfractor/
 .vscode/tasks.json
 /src/tensorflow2.x-python-tutorial/my_model
+
+.ionide

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Example runner will download all the required files like training data and model
 * Hello World [C#](src/TensorFlowNET.Examples/HelloWorld.cs)
 * Basic Operations [C#](src/TensorFlowNET.Examples/BasicOperations.cs)
 * Linear Regression in Graph mode [C#](src/TensorFlowNET.Examples/BasicModels/LinearRegression.cs) 
-* Linear Regression in Eager mode [C#](src/TensorFlowNET.Examples/BasicModels/LinearRegressionEager.cs), [F#](src/TensorFlowNET.Examples/BasicModels/LinearRegressionEager.fs)
+* Linear Regression in Eager mode [C#](src/TensorFlowNET.Examples/BasicModels/LinearRegressionEager.cs), [F#](src/TensorFlowNET.Examples.FSharp/BasicModels/LinearRegressionEager.fs)
 * Logistic Regression in Graph mode [C#](src/TensorFlowNET.Examples/BasicModels/LogisticRegression.cs)
 * Logistic Regression in Eager mode [C#](src/TensorFlowNET.Examples/BasicModels/LogisticRegressionEager.cs) 
 * Nearest Neighbor [C#](src/TensorFlowNET.Examples/BasicModels/NearestNeighbor.cs)

--- a/README.md
+++ b/README.md
@@ -30,27 +30,27 @@ dotnet TensorFlowNET.Examples.dll -ex "MNIST CNN (Eager)"
 
 Example runner will download all the required files like training data and model pb files.
 
-* [Hello World](src/TensorFlowNET.Examples/HelloWorld.cs)
-* [Basic Operations](src/TensorFlowNET.Examples/BasicOperations.cs)
-* [Linear Regression](src/TensorFlowNET.Examples/BasicModels/LinearRegression.cs) in Graph mode
-* [Linear Regression](src/TensorFlowNET.Examples/BasicModels/LinearRegressionEager.cs) in Eager mode
-* [Logistic Regression](src/TensorFlowNET.Examples/BasicModels/LogisticRegression.cs) in Graph mode
-* [Logistic Regression](src/TensorFlowNET.Examples/BasicModels/LogisticRegressionEager.cs) in Eager mode
-* [Nearest Neighbor](src/TensorFlowNET.Examples/BasicModels/NearestNeighbor.cs)
-* [Naive Bayes Classification](src/TensorFlowNET.Examples/BasicModels/NaiveBayesClassifier.cs)
-* [Full Connected Neural Network](src/TensorFlowNET.Examples/\NeuralNetworks/FullyConnectedEager.cs) in Eager mode
-* [K-means Clustering](src/TensorFlowNET.Examples/BasicModels/KMeansClustering.cs)
-* [NN XOR](src/TensorFlowNET.Examples/NeuralNetworks/NeuralNetXor.cs)
-* [Object Detection](src/TensorFlowNET.Examples/ObjectDetection/DetectInMobilenet.cs) in MobileNet
-* [Binary Text Classification](src/TensorFlowNET.Examples/TextProcessing/BinaryTextClassification.cs)
-* [CNN Text Classification](src/TensorFlowNET.Examples/TextProcessing/cnn_models/VdCnn.cs)
-* [MNIST FNN](src/TensorFlowNET.Examples/ImageProcessing/MnistFnnKerasFunctional.cs) in Keras Functional API
-* [MNIST CNN](src/TensorFlowNET.Examples/ImageProcessing/DigitRecognitionCNN.cs) in Graph mode
-* [MNIST RNN](src/TensorFlowNET.Examples/ImageProcessing/DigitRecognitionRNN.cs)
-* [MNIST LSTM](src/TensorFlowNET.Examples/ImageProcessing/DigitRecognitionLSTM.cs)
-* [Named Entity Recognition](src/TensorFlowNET.Examples/TextProcessing/NER)
-* [Transfer Learning for Image Classification](src/TensorFlowNET.Examples/ImageProcessing/TransferLearningWithInceptionV3.cs) in InceptionV3
-* [CNN In Your Own Dataset](src/TensorFlowNET.Examples/ImageProcessing/CnnInYourOwnData.cs)
+* Hello World [C#](src/TensorFlowNET.Examples/HelloWorld.cs)
+* Basic Operations [C#](src/TensorFlowNET.Examples/BasicOperations.cs)
+* Linear Regression in Graph mode [C#](src/TensorFlowNET.Examples/BasicModels/LinearRegression.cs) 
+* Linear Regression in Eager mode [C#](src/TensorFlowNET.Examples/BasicModels/LinearRegressionEager.cs), [F#](src/TensorFlowNET.Examples/BasicModels/LinearRegressionEager.fs)
+* Logistic Regression in Graph mode [C#](src/TensorFlowNET.Examples/BasicModels/LogisticRegression.cs)
+* Logistic Regression in Eager mode [C#](src/TensorFlowNET.Examples/BasicModels/LogisticRegressionEager.cs) 
+* Nearest Neighbor [C#](src/TensorFlowNET.Examples/BasicModels/NearestNeighbor.cs)
+* Naive Bayes Classification [C#](src/TensorFlowNET.Examples/BasicModels/NaiveBayesClassifier.cs)
+* Full Connected Neural Network in Eager mode [C#](src/TensorFlowNET.Examples/\NeuralNetworks/FullyConnectedEager.cs) 
+* K-means Clustering [C#](src/TensorFlowNET.Examples/BasicModels/KMeansClustering.cs)
+* NN XOR [C#](src/TensorFlowNET.Examples/NeuralNetworks/NeuralNetXor.cs)
+* Object Detection in MobileNet [C#](src/TensorFlowNET.Examples/ObjectDetection/DetectInMobilenet.cs) 
+* Binary Text Classification [C#](src/TensorFlowNET.Examples/TextProcessing/BinaryTextClassification.cs)
+* CNN Text Classification [C#](src/TensorFlowNET.Examples/TextProcessing/cnn_models/VdCnn.cs)
+* MNIST FNN in Keras Functional API [C#](src/TensorFlowNET.Examples/ImageProcessing/MnistFnnKerasFunctional.cs) 
+* MNIST CNN in Graph mode [C#](src/TensorFlowNET.Examples/ImageProcessing/DigitRecognitionCNN.cs) 
+* MNIST RNN [C#](src/TensorFlowNET.Examples/ImageProcessing/DigitRecognitionRNN.cs)
+* MNIST LSTM [C#](src/TensorFlowNET.Examples/ImageProcessing/DigitRecognitionLSTM.cs)
+* Named Entity Recognition [C#](src/TensorFlowNET.Examples/TextProcessing/NER)
+* Transfer Learning for Image Classification in InceptionV3 [C#](src/TensorFlowNET.Examples/ImageProcessing/TransferLearningWithInceptionV3.cs)
+* CNN In Your Own Dataset [C#](src/TensorFlowNET.Examples/ImageProcessing/CnnInYourOwnData.cs)
 
 
 ### Welcome to PR your example to us.

--- a/src/TensorFlowNET.Examples.FSharp/BasicModels/LinearRegressionEager.fs
+++ b/src/TensorFlowNET.Examples.FSharp/BasicModels/LinearRegressionEager.fs
@@ -1,0 +1,72 @@
+﻿(******************************************************************************
+Copyright 2018 The TensorFlow.NET Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+******************************************************************************)
+
+namespace TensorFlow.NET.Examples.FSharp
+
+open NumSharp
+open Tensorflow
+open type Tensorflow.Binding
+open type Tensorflow.KerasApi
+
+/// <summary>
+/// A linear regression learning algorithm example using TensorFlow library.
+/// https://github.com/aymericdamien/TensorFlow-Examples/blob/master/tensorflow_v2/notebooks/2_BasicModels/linear_regression.ipynb
+/// </summary>
+
+module LinearRegressionEager =
+    let run() =
+        let tf = New<tensorflow>()
+        tf.enable_eager_execution()
+        
+        let training_steps = 1000
+        let learning_rate = 0.01f
+        let display_step = 100
+        
+        let train_X = 
+            np.array(3.3f, 4.4f, 5.5f, 6.71f, 6.93f, 4.168f, 9.779f, 6.182f, 7.59f, 2.167f,
+                     7.042f, 10.791f, 5.313f, 7.997f, 5.654f, 9.27f, 3.1f)
+        let train_Y = 
+            np.array(1.7f, 2.76f, 2.09f, 3.19f, 1.694f, 1.573f, 3.366f, 2.596f, 2.53f, 1.221f,
+                     2.827f, 3.465f, 1.65f, 2.904f, 2.42f, 2.94f, 1.3f)
+        let n_samples = train_X.shape.[0]
+        
+        // We can set a fixed init value in order to demo
+        let W = tf.Variable(-0.06f,name = "weight")
+        let b = tf.Variable(-0.73f, name = "bias")
+        let optimizer = keras.optimizers.SGD(learning_rate)
+        
+        // Run training for the given number of steps.
+        for step = 1 to  (training_steps + 1) do 
+            // Run the optimization to update W and b values.
+            // Wrap computation inside a GradientTape for automatic differentiation.
+            use g = tf.GradientTape()
+            // Linear regression (Wx + b).
+            let pred = W * train_X + b
+            // Mean square error.
+            let loss = tf.reduce_sum(tf.pow(pred - train_Y,2)) / (2 * n_samples)
+            // should stop recording
+            // compute gradients
+            let gradients = g.gradient(loss,struct (W,b))
+        
+            // Update W and b following gradients.
+            optimizer.apply_gradients(zip(gradients, struct (W,b)))
+        
+            if (step % display_step) = 0 then
+                let pred = W * train_X + b
+                let loss = tf.reduce_sum(tf.pow(pred-train_Y,2)) / (2 * n_samples)
+                printfn $"step: {step}, loss: {loss.numpy()}, W: {W.numpy()}, b: {b.numpy()}"
+        
+        

--- a/src/TensorFlowNET.Examples.FSharp/FunctionApproximation.fs
+++ b/src/TensorFlowNET.Examples.FSharp/FunctionApproximation.fs
@@ -40,32 +40,33 @@ let run()=
     let n_hidden_layer_2 = 25 // Hidden layer 2
 
     let tf = Binding.New<tensorflow>()
+    tf.enable_eager_execution()
     let x = tf.placeholder(tf.float64, new TensorShape(N_points,n_input))
     let y = tf.placeholder(tf.float64, new TensorShape(n_output))
     
    
     let weights = dict[
-        "hidden_layer_1", tf.Variable(tf.random_normal([|n_input; n_hidden_layer_1|],dtype=tf.float64))
-        "hidden_layer_2", tf.Variable(tf.random_normal([|n_hidden_layer_1; n_hidden_layer_2|],dtype=tf.float64))
-        "out", tf.Variable(tf.random_normal([|n_hidden_layer_2; n_output|],dtype=tf.float64))
+        "hidden_layer_1", tf.Variable(tf.random.normal(TensorShape [|n_input; n_hidden_layer_1|],dtype=tf.float64))
+        "hidden_layer_2", tf.Variable(tf.random.normal(TensorShape [|n_hidden_layer_1; n_hidden_layer_2|],dtype=tf.float64))
+        "out", tf.Variable(tf.random.normal(TensorShape [|n_hidden_layer_2; n_output|],dtype=tf.float64))
     ]
     let biases = dict[
-        "hidden_layer_1", tf.Variable(tf.random_normal([|n_hidden_layer_1|],dtype=tf.float64))
-        "hidden_layer_2", tf.Variable(tf.random_normal([|n_hidden_layer_2|],dtype=tf.float64))
-        "out", tf.Variable(tf.random_normal([|n_output|],dtype=tf.float64))
+        "hidden_layer_1", tf.Variable(tf.random.normal(TensorShape [|n_hidden_layer_1|],dtype=tf.float64))
+        "hidden_layer_2", tf.Variable(tf.random.normal(TensorShape [|n_hidden_layer_2|],dtype=tf.float64))
+        "out", tf.Variable(tf.random.normal(TensorShape [|n_output|],dtype=tf.float64))
     ]
 
  
     // Hidden layer with RELU activation
 
-    let layer_1 = tf.add(tf.matmul(x, weights.["hidden_layer_1"]._AsTensor()),biases.["hidden_layer_1"])
+    let layer_1 = tf.add(tf.matmul(x, weights.["hidden_layer_1"].AsTensor()),biases.["hidden_layer_1"])
     let layer_1 = tf.nn.relu(layer_1)
 
-    let layer_2 = tf.add(tf.matmul(layer_1, weights.["hidden_layer_2"]._AsTensor()),biases.["hidden_layer_2"])
+    let layer_2 = tf.add(tf.matmul(layer_1, weights.["hidden_layer_2"].AsTensor()),biases.["hidden_layer_2"])
     let layer_2 = tf.nn.relu(layer_2)
 
     // Output layer with linear activation
-    let ops = tf.add(tf.matmul(layer_2, weights.["out"]._AsTensor()), biases.["out"])
+    let ops = tf.add(tf.matmul(layer_2, weights.["out"].AsTensor()), biases.["out"])
     
     // Define loss and optimizer
     let cost = tf.reduce_mean(tf.square(tf.squeeze(ops)-y))
@@ -83,7 +84,7 @@ let run()=
         for epoch in [0..training_epochs] do
             // Run optimization process (backprop) and cost function (to get loss value)
 
-            let result=sess.run([|optimizer:>ITensorOrOperation; gs._AsTensor():>ITensorOrOperation; cost:>ITensorOrOperation|], new FeedItem(x, X_train), new FeedItem(y, y_train))
+            let result=sess.run([|optimizer:>ITensorOrOperation; gs.AsTensor():>ITensorOrOperation; cost:>ITensorOrOperation|], new FeedItem(x, X_train), new FeedItem(y, y_train))
 
 
             let loss_value = (double) result.[2];

--- a/src/TensorFlowNET.Examples.FSharp/Program.fs
+++ b/src/TensorFlowNET.Examples.FSharp/Program.fs
@@ -1,8 +1,10 @@
 ﻿// Learn more about F# at http://fsharp.org
 
 open System
+open TensorFlow.NET.Examples.FSharp
 
 [<EntryPoint>]
 let main argv =
-    FunctionApproximation.run()
+    //FunctionApproximation.run() // Still Needs updates
+    LinearRegressionEager.run()
     0 // return an integer exit code

--- a/src/TensorFlowNET.Examples.FSharp/TensorFlowNET.Examples.FSharp.fsproj
+++ b/src/TensorFlowNET.Examples.FSharp/TensorFlowNET.Examples.FSharp.fsproj
@@ -7,17 +7,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="BasicModels\LinearRegressionEager.fs" />
     <Compile Include="FunctionApproximation.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.15.0" />
-    <PackageReference Include="TensorFlow.NET" Version="0.12.0" />
+    <PackageReference Include="Colorful.Console" Version="1.2.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.4.0.20200915" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.3.1" />
+    <PackageReference Include="SharpCV" Version="0.6.0" />
+    <PackageReference Include="SharpZipLib" Version="1.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="TensorFlow.Keras" Version="0.1.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- I updated the F# project to the newer tensforflow.NET libraries by copying over the references from the C# project.
- I added LinearRegressionEager.fs
- I am commenting out FunctionApproximation.fs because it relies on the old API and it is easier to start by porting the existing C# examples that use the current API. 
- I updated the readme to the `C#, F#` format suggested by @Oceania2018. 